### PR TITLE
From Cordova 4 setActivityResultCallback is on CordovaInterfaceImpl

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -29,7 +29,6 @@
   <!-- android -->
   <platform name="android">
 
-    <dependency id="android.support.v4@21.0.1" url="https://github.com/MobileChromeApps/cordova-plugin-android-support-v4" />
     <dependency id="com.google.playservices@21.0.0" url="https://github.com/MobileChromeApps/google-play-services" />
 
     <config-file target="res/xml/config.xml" parent="/*">

--- a/src/android/GooglePlus.java
+++ b/src/android/GooglePlus.java
@@ -248,7 +248,7 @@ public class GooglePlus extends CordovaPlugin implements ConnectionCallbacks, On
       try {
         // startIntentSenderForResult is started from the CordovaActivity,
         // set callback to this plugin to make sure this.onActivityResult gets called afterwards
-        ((CordovaActivity) this.cordova.getActivity()).setActivityResultCallback(this);
+        this.cordova.setActivityResultCallback(this);
         this.cordova.getActivity().startIntentSenderForResult(mSignInIntent.getIntentSender(), 0, null, 0, 0, 0);
       } catch (IntentSender.SendIntentException ignore) {
         mGoogleApiClient.connect();


### PR DESCRIPTION
I was having problems building the APK (using Ionic with Crosswalk) because the compiler couldn't find the setActivityResultCallback on CordovaActivity.

After a long search I found that in Cordova 4 setActivityResultCallback is no longer on CordovaActivity but on CordovaInterfaceImpl, so I made the changes.

I don't know if this pull request will break backward compatibility with Cordova 3.x, can someone check that?