### PR TITLE
Update dependencies to gradle format to fix #64

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -29,8 +29,8 @@
   <!-- android -->
   <platform name="android">
 
-    <framework src="com.google.android.gms:play-services-plus" />
-    <framework src="com.google.android.gms:play-services-identity" />
+    <framework src="com.google.android.gms:play-services-plus:+" />
+    <framework src="com.google.android.gms:play-services-identity:+" />
 
     <config-file target="res/xml/config.xml" parent="/*">
       <feature name="GooglePlus">


### PR DESCRIPTION
I was successful in building the latest release by installing the latest version:

    cordova plugin add cordova-plugin-googleplus

and then making the changes included in this PR.

Please note that on android it is required to have "Android Support Repository" and "Google Repository" installed through the Android SDK Manager.
