### PR TITLE
access_token fix for iOS

### DIFF
--- a/src/ios/GooglePlus.m
+++ b/src/ios/GooglePlus.m
@@ -247,6 +247,7 @@ didSignInForUser:(GIDGoogleUser *)user
                        @"email"       : email,
                        @"idToken"     : token,
                        @"oauthToken"  : serverAuthCode,
+                       @"accessToken" : accessToken,
                        @"userId"      : userId,
                        @"displayName" : user.profile.name ?: [NSNull null]/*,
                        @"gender"      : person.gender ?: [NSNull null],


### PR DESCRIPTION
Hi @EddyVerbruggen,

The access_token will now be returned on iOS as: accessToken
Fixed: #70 