### PR TITLE
Added the option to generate Cross-client access token on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Android
 <img src="https://raw.githubusercontent.com/EddyVerbruggen/cordova-plugin-googleplus/master/screenshots/Android3.png" width="235" height="400"/>
 
  iOS
- 
+
 <img src="https://raw.githubusercontent.com/EddyVerbruggen/cordova-plugin-googleplus/master/screenshots/iOS1.png" width="235" height="417"/>&nbsp;
 <img src="https://raw.githubusercontent.com/EddyVerbruggen/cordova-plugin-googleplus/master/screenshots/iOS2.png" width="235" height="417"/>&nbsp;
 <img src="https://raw.githubusercontent.com/EddyVerbruggen/cordova-plugin-googleplus/master/screenshots/iOS3.png" width="235" height="417"/>&nbsp;
@@ -98,6 +98,7 @@ window.plugins.googleplus.isAvailable(
 window.plugins.googleplus.login(
     {
       'scopes': '... ', // optional space-separated list of scopes, the default is sufficient for login and basic profile info
+      'webApiKey': 'api of web app', // optional API key of your Web application from Credentials settings of your project - if you set it the returned idToken will allow sign in to services like Azure Mobile Services
       // there is no API key for Android; you app is wired to the Google+ API by listing your package name in the google dev console and signing your apk (which you have done in chapter 4)
     },
     function (obj) {
@@ -138,7 +139,9 @@ but if it fails it will not show the authentication dialog to the user.
 The code is exactly the same a `login`, except for the function name.
 ```javascript
 window.plugins.googleplus.trySilentLogin(
-    {},
+    {
+      'webApiKey': 'api of web app', // optional API key of your Web application from Credentials settings of your project - if you set it the returned idToken will allow sign in to services like Azure Mobile Services 
+    },
     function (obj) {
       alert(JSON.stringify(obj)); // do something useful instead of alerting
     },

--- a/src/ios/GooglePlus.m
+++ b/src/ios/GooglePlus.m
@@ -127,9 +127,15 @@ static void swizzleMethod(Class class, SEL destinationSelector, SEL sourceSelect
     NSString *clientId = [self reverseUrlScheme:reversedClientId];
   
     NSString* scopesString = [options objectForKey:@"scopes"];
-  
+    NSString* serverClientId = [options objectForKey:@"webApiKey"];
+
     GIDSignIn *signIn = [GIDSignIn sharedInstance];
     signIn.clientID = clientId;
+
+    if (serverClientId != nil) {
+      signIn.serverClientID = serverClientId;
+    }
+
     signIn.allowsSignInWithBrowser = NO; // Otherwise your app get rejected
     signIn.uiDelegate = self;
     signIn.delegate = self;


### PR DESCRIPTION
Implemented the feature according to the guide:
https://developers.google.com/identity/sign-in/ios/offline-access

The idTokens generated without setting the web API key don't work with services like Azure Mobile Services. This pull request fixes that.