### PR TITLE
Added an option to generate access token for offline access on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ window.plugins.googleplus.isAvailable(
 window.plugins.googleplus.login(
     {
       'scopes': '... ', // optional space-separated list of scopes, the default is sufficient for login and basic profile info
+      'offline': true, // optional and required for Android only - if set to true the plugin will also return the OAuth access token, that can be used to sign in to some third party services that don't accept a Cross-client identity token (ex. Firebase)
       // there is no API key for Android; you app is wired to the Google+ API by listing your package name in the google dev console and signing your apk (which you have done in chapter 4)
     },
     function (obj) {
@@ -138,7 +139,9 @@ but if it fails it will not show the authentication dialog to the user.
 The code is exactly the same a `login`, except for the function name.
 ```javascript
 window.plugins.googleplus.trySilentLogin(
-    {},
+    {
+      'offline': true // optional and required for Android only - if set to true the plugin will also return the OAuth access token, that can be used to sign in to some third party services that don't accept a Cross-client identity token (ex. Firebase)
+    },
     function (obj) {
       alert(JSON.stringify(obj)); // do something useful instead of alerting
     },

--- a/src/android/GooglePlus.java
+++ b/src/android/GooglePlus.java
@@ -184,13 +184,15 @@ public class GooglePlus extends CordovaPlugin implements ConnectionCallbacks, On
             scope = "audience:server:client_id:" + GooglePlus.this.webKey;
             token = GoogleAuthUtil.getToken(context, email, scope);
             result.put("idToken", token);
-          } else if (GooglePlus.this.apiKey != null) {
+          }
+          if (GooglePlus.this.apiKey != null) {
             // Retrieve the oauth token with offline mode
             scope = "oauth2:server:client_id:" + GooglePlus.this.apiKey;
             scope += ":api_scope:" + GooglePlus.this.scopesString;
             token = GoogleAuthUtil.getToken(context, email, scope);
             result.put("oauthToken", token);
-          } else {
+          }
+          if (GooglePlus.this.webKey == null && GooglePlus.this.apiKey == null) {
             // Retrieve the oauth token with offline mode
             scope = "oauth2:" + Scopes.PLUS_LOGIN;
             token = GoogleAuthUtil.getToken(context, email, scope);


### PR DESCRIPTION
Some services require an access_token instead of id_token to enable sign-in with Google+ (ex. Firebase). In such a case the `oauthToken` needs to be generated as well. For some reason setting the scope to `oauth2:server:client_id:...` resulted in an exception.

Also split the `if..else` so both the `idToken` and `oauthToken` can be returned in a single `login/trySilentLogin` call just like it works on iOS.