### PR TITLE
Android: Ensure a new one time token on each login

### DIFF
--- a/src/android/GooglePlus.java
+++ b/src/android/GooglePlus.java
@@ -195,6 +195,9 @@ public class GooglePlus extends CordovaPlugin implements ConnectionCallbacks, On
             scope = "oauth2:server:client_id:" + GooglePlus.this.apiKey;
             scope += ":api_scope:" + GooglePlus.this.scopesString;
             token = GoogleAuthUtil.getToken(context, email, scope);
+            // Since this is a short-lived one time token immediately remove it from
+            // the cache. This ensures a new token each time the user authenticates.
+            GoogleAuthUtil.clearToken(context, token);
             result.put("oauthToken", token);
           } else if(GooglePlus.this.requestOfflineToken) {
             // Retrieve the oauth token with offline mode


### PR DESCRIPTION
When using the `androidApiKey` parameter a short-lived one time token
is generated, which can then be passed to the server where it can be
exchanged for a proper access and refresh token. Since all tokens get
cached by `GoogleAuthUtil` logging in a second time will cause the token
to be invalid if it was used before or some time has passed.

I am not quite sure if we should do the same when `GooglePlus.this.requestOfflineToken` is used.