### PR TITLE
Fix issues with phonegap-facebook-plugin

### DIFF
--- a/src/ios/GooglePlus.m
+++ b/src/ios/GooglePlus.m
@@ -63,8 +63,16 @@ static void swizzleMethod(Class class, SEL destinationSelector, SEL sourceSelect
 }
 
 - (void) login:(CDVInvokedUrlCommand*)command {
-  self.isSigningIn = YES;
-//  [[self getGooglePlusSignInObject:command] authenticate];
+    BOOL appInstalled = [[UIApplication sharedApplication] canOpenURL: [NSURL URLWithString:@"com-google-gidconsent-google://"]];
+    if (appInstalled)
+    {
+        self.isSigningIn = YES;
+    }
+    else
+    {
+        self.isSigningIn = NO;   
+    }
+  //  [[self getGooglePlusSignInObject:command] authenticate];
   [[self getGIDSignInObject:command] signIn];
 }
 
@@ -83,7 +91,15 @@ static void swizzleMethod(Class class, SEL destinationSelector, SEL sourceSelect
  @date July 19, 2015
  */
 - (void) trySilentLogin:(CDVInvokedUrlCommand*)command {
-    self.isSigningIn = YES;
+    BOOL appInstalled = [[UIApplication sharedApplication] canOpenURL: [NSURL URLWithString:@"com-google-gidconsent-google://"]];
+    if (appInstalled)
+    {
+        self.isSigningIn = YES;
+    }
+    else
+    {
+        self.isSigningIn = NO;   
+    }
     [[self getGIDSignInObject:command] signInSilently];
 }
 


### PR DESCRIPTION
setting isSigningIn = YES even when Google app is not installed will cause issues in receiving callbacks from other plugins