### PR TITLE
Android: Gets a new offline token on each login

### DIFF
--- a/src/android/GooglePlus.java
+++ b/src/android/GooglePlus.java
@@ -208,6 +208,9 @@ public class GooglePlus extends CordovaPlugin implements ConnectionCallbacks, On
             // Retrieve the oauth token with offline mode
             scope = "oauth2:" + Scopes.PLUS_LOGIN;
             token = GoogleAuthUtil.getToken(context, email, scope);
+            // Since this is a short-lived one time token immediately remove it from
+            // the cache. This ensures a new token each time the user authenticates.
+            GoogleAuthUtil.clearToken(context, token);
             result.put("oauthToken", token);
           }
         }


### PR DESCRIPTION
Based on https://github.com/EddyVerbruggen/cordova-plugin-googleplus/pull/119
I tested this on an app I'm working where every authentication attempt returned the same invalid token. After applying this change, the authentication works fine each time.