### PR TITLE
Fix Google Play Services dependencies

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -29,8 +29,8 @@
   <!-- android -->
   <platform name="android">
 
-    <framework src="com.google.android.gms:play-services-auth:+" />
-    <framework src="com.google.android.gms:play-services-identity:+" />
+    <framework src="com.google.android.gms:play-services-auth:9.0.2" />
+    <framework src="com.google.android.gms:play-services-identity:9.0.2" />
 
     <config-file target="res/xml/config.xml" parent="/*">
       <feature name="GooglePlus">


### PR DESCRIPTION
Latest play services release breaks build. By using 9.0.2 everything works. Check also [this issue comment](https://github.com/RocketChat/Rocket.Chat.Cordova/issues/118#issuecomment-230415907).
This is what I get when I build [Rocket.Chat.Cordova](https://github.com/RocketChat/Rocket.Chat.Cordova) project which uses this plugin:
```
:compileArmv7DebugJavaWithJavac/Users/alex/workspace/Rocket.Chat.Cordova/platforms/android/src/nl/xservices/plugins/GooglePlus.java:11: error: package com.google.android.gms.auth does not exist
import com.google.android.gms.auth.GoogleAuthException;
                                  ^
/Users/alex/workspace/Rocket.Chat.Cordova/platforms/android/src/nl/xservices/plugins/GooglePlus.java:12: error: package com.google.android.gms.auth does not exist
import com.google.android.gms.auth.GoogleAuthUtil;
                                  ^
/Users/alex/workspace/Rocket.Chat.Cordova/platforms/android/src/nl/xservices/plugins/GooglePlus.java:13: error: package com.google.android.gms.auth does not exist
import com.google.android.gms.auth.UserRecoverableAuthException;
                                  ^
/Users/alex/workspace/Rocket.Chat.Cordova/platforms/android/src/nl/xservices/plugins/GooglePlus.java:193: error: cannot find symbol
            token = GoogleAuthUtil.getToken(context, email, scope);
                    ^
  symbol: variable GoogleAuthUtil
/Users/alex/workspace/Rocket.Chat.Cordova/platforms/android/src/nl/xservices/plugins/GooglePlus.java:202: error: cannot find symbol
            token = GoogleAuthUtil.getToken(context, email, scope);
                    ^
  symbol: variable GoogleAuthUtil
/Users/alex/workspace/Rocket.Chat.Cordova/platforms/android/src/nl/xservices/plugins/GooglePlus.java:205: error: cannot find symbol
            GoogleAuthUtil.clearToken(context, token);
            ^
  symbol: variable GoogleAuthUtil
/Users/alex/workspace/Rocket.Chat.Cordova/platforms/android/src/nl/xservices/plugins/GooglePlus.java:210: error: cannot find symbol
            token = GoogleAuthUtil.getToken(context, email, scope);
                    ^
  symbol: variable GoogleAuthUtil
/Users/alex/workspace/Rocket.Chat.Cordova/platforms/android/src/nl/xservices/plugins/GooglePlus.java:213: error: cannot find symbol
            GoogleAuthUtil.clearToken(context, token);
            ^
  symbol: variable GoogleAuthUtil
/Users/alex/workspace/Rocket.Chat.Cordova/platforms/android/src/nl/xservices/plugins/GooglePlus.java:217: error: cannot find symbol
        catch (UserRecoverableAuthException userAuthEx) {
               ^
  symbol: class UserRecoverableAuthException
/Users/alex/workspace/Rocket.Chat.Cordova/platforms/android/src/nl/xservices/plugins/GooglePlus.java:227: error: cannot find symbol
        } catch (GoogleAuthException e) {
                 ^
  symbol: class GoogleAuthException
```
After the proposed fix in the pull request, the build is successful.