### PR TITLE
Hosted Domain

### DIFF
--- a/src/android/GooglePlus.java
+++ b/src/android/GooglePlus.java
@@ -39,6 +39,7 @@ public class GooglePlus extends CordovaPlugin implements GoogleApiClient.OnConne
     public static final String ARGUMENT_WEB_CLIENT_ID = "webClientId";
     public static final String ARGUMENT_SCOPES = "scopes";
     public static final String ARGUMENT_OFFLINE_KEY = "offline";
+    public static final String ARGUMENT_HOSTED_DOMAIN = "hostedDomain";
 
     public static final String TAG = "GooglePlugin";
     public static final int RC_GOOGLEPLUS = 77552; // Request Code to identify our plugin's activities
@@ -141,6 +142,14 @@ public class GooglePlus extends CordovaPlugin implements GoogleApiClient.OnConne
             if (clientOptions.optBoolean(ARGUMENT_OFFLINE_KEY, false)) {
                 gso.requestServerAuthCode(webClientId, false);
             }
+        }
+
+        // Try to get hosted domain
+        String hostedDomain = clientOptions.optString(ARGUMENT_HOSTED_DOMAIN, null);
+
+        // if hostedDomain included, we'll request a hosted domain account
+        if (hostedDomain != null && !hostedDomain.isEmpty()) {
+            gso.setHostedDomain(hostedDomain);
         }
 
         //Now that we have our options, let's build our Client

--- a/src/ios/GooglePlus.m
+++ b/src/ios/GooglePlus.m
@@ -112,6 +112,7 @@ Fixes issue with G+ login window not closing correctly on ios 9
     NSString* serverClientId = options[@"webClientId"];
     NSString *loginHint = options[@"loginHint"];
     BOOL offline = [options[@"offline"] boolValue];
+    NSString* hostedDomain = options[@"hostedDomain"];
 
 
     GIDSignIn *signIn = [GIDSignIn sharedInstance];
@@ -121,6 +122,10 @@ Fixes issue with G+ login window not closing correctly on ios 9
 
     if (serverClientId != nil && offline) {
       signIn.serverClientID = serverClientId;
+    }
+    
+    if (hostedDomain != nil) {
+        signIn.hostedDomain = hostedDomain;
     }
 
     signIn.uiDelegate = self;


### PR DESCRIPTION
By submitting “hostedDomain” parameter (e.g.
hostedDomain:“mydomainname.com”) the google login will ask the user to
login using an account under that domain.
The account selection will display from the existing (in your device),
only google accounts under that domain, making the selection of the
account easier.

Therfore this doesn’t stop the user from signing in with another
account neither validates the account as member of the domain.
The user will be able to proceed to login with with any google account
if they go through the “add new account”.
It is just up to the developer to do additional check, as google
doesn’t provide an easy way to do it yet.

Note: I think that in android the webClientId is required in order the
hostedDomain to work, but in iOS it is not necessary.