### PR TITLE
make iOS return givenName and familyName like Android

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -29,8 +29,8 @@
   <!-- android -->
   <platform name="android">
 
-    <framework src="com.google.android.gms:play-services-auth:9.2.0" />
-    <framework src="com.google.android.gms:play-services-identity:9.2.0" />
+    <framework src="com.google.android.gms:play-services-auth:+" />
+    <framework src="com.google.android.gms:play-services-identity:+" />
 
     <config-file target="res/xml/config.xml" parent="/*">
       <feature name="GooglePlus">

--- a/plugin.xml
+++ b/plugin.xml
@@ -29,8 +29,8 @@
   <!-- android -->
   <platform name="android">
 
-    <framework src="com.google.android.gms:play-services-auth:+" />
-    <framework src="com.google.android.gms:play-services-identity:+" />
+    <framework src="com.google.android.gms:play-services-auth:9.2.0" />
+    <framework src="com.google.android.gms:play-services-identity:9.2.0" />
 
     <config-file target="res/xml/config.xml" parent="/*">
       <feature name="GooglePlus">

--- a/src/ios/GooglePlus.m
+++ b/src/ios/GooglePlus.m
@@ -203,6 +203,8 @@ Fixes issue with G+ login window not closing correctly on ios 9
                        @"refreshToken"    : refreshToken,
                        @"userId"          : userId,
                        @"displayName"     : user.profile.name ? : [NSNull null],
+                       @"givenName"       : user.profile.givenName ? : [NSNull null],
+                       @"familyName"      : user.profile.familyName ? : [NSNull null],
                        @"imageUrl"        : imageUrl ? imageUrl.absoluteString : [NSNull null],
                        };
 


### PR DESCRIPTION
Hi @EddyVerbruggen, 

The iOS code was not returning the same fields as Android. There still seems to be some missing in Android too.

Cheers, 
Joel