### PR TITLE
Fix for application:openURL:options: swizzling on iOS

### DIFF
--- a/src/ios/GooglePlus.m
+++ b/src/ios/GooglePlus.m
@@ -62,10 +62,8 @@ Fixes issue with G+ login window not closing correctly on ios 9
             sourceApplication:options[UIApplicationOpenURLOptionsSourceApplicationKey]
             annotation:options[UIApplicationOpenURLOptionsAnnotationKey]];
     } else {
-        // Other
-        return [self application:app openURL:url
-            sourceApplication:options[UIApplicationOpenURLOptionsSourceApplicationKey]
-            annotation:options[UIApplicationOpenURLOptionsAnnotationKey]];
+        // call super
+        return [self indentity_application_options:app openURL:url options:options];
     }
 }
 @end


### PR DESCRIPTION
Current swizzle cut off further invocations of default application:openURL:options: method, creating problems if, for example, more URL are to be managed.