### PR TITLE
Google frameworks should not be embedded.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -81,12 +81,12 @@
 
     <!-- Google frameworks -->
     <!-- Downloaded here: https://developers.google.com/identity/sign-in/ios/sdk/ (changelog: https://developers.google.com/identity/sign-in/ios/release) -->
-    <framework src="src/ios/libs/GoogleAppUtilities.framework" custom="true" />
-    <framework src="src/ios/libs/GoogleAuthUtilities.framework" custom="true" />
-    <framework src="src/ios/libs/GoogleNetworkingUtilities.framework" custom="true" />
-    <framework src="src/ios/libs/GoogleSignIn.framework" custom="true" />
-    <framework src="src/ios/libs/GoogleSymbolUtilities.framework" custom="true" />
-    <framework src="src/ios/libs/GoogleUtilities.framework" custom="true" />
+    <framework src="src/ios/libs/GoogleAppUtilities.framework" custom="false" />
+    <framework src="src/ios/libs/GoogleAuthUtilities.framework" custom="false" />
+    <framework src="src/ios/libs/GoogleNetworkingUtilities.framework" custom="false" />
+    <framework src="src/ios/libs/GoogleSignIn.framework" custom="false" />
+    <framework src="src/ios/libs/GoogleSymbolUtilities.framework" custom="false" />
+    <framework src="src/ios/libs/GoogleUtilities.framework" custom="false" />
 
     <!-- System frameworks -->
     <framework src="AddressBook.framework" weak="true" />


### PR DESCRIPTION
Google frameworks should not be embedded as it was built in similar way as system frameworks.
Google might provide an update in future to this make it embedded by using Xcode framework targets to build.