### PR TITLE
Add Google Play specific instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ $ keytool -exportcert -keystore <path-to-debug-or-production-keystore> -list -v 
 ```
 Login on Android will use the accounts signed in on the user's device.
 
+#### Publishing your app in Google Play Store
+
+Google re-signs your app with a different certificate when you publish it in the Play Store. Once your app is published, copy the SHA-1 fingerprint of the "App signing certificate", found in the "App signing" section under "Release Management", in [Google Play Console](https://play.google.com/apps/publish/). Paste this fingerprint in the Release OAuth client ID in [Google Credentials Manager](https://console.developers.google.com/apis/credentials).
+
 ### Web Client Id
 
 If you want to get an `idToken` or `serverAuthCode` back from the Sign In Process, you will need to pass the client ID for your project's web application. This can be found on your project's API credentials page on the [Google Developer's Console](https://console.developers.google.com/).


### PR DESCRIPTION
We have been using this plugin without problems both in debug and release mode, but when publishing our app and downloading it via Google Play, Google Sign in was returning an "error 10".

After some days trying to solve the error (especially trying all the solutions proposed in #243 ), we realized, thanks to some comments in issues #424 and #404, that Google re-signs the apps once they are published in Google Play, so we needed to update the fingerprint in the Release OAuth client ID.

I think this should be explained in the README instructions, it will save time and headaches to developers using this extension.

Note: I'm not sure that I used the correct terminology regarding signing, fingerprints and certificates in the instructions I added. I tend to get lost when dealing with app certificates.