### PR TITLE
Fix handle multiple url types

### DIFF
--- a/src/ios/GooglePlus.m
+++ b/src/ios/GooglePlus.m
@@ -13,62 +13,17 @@
  @author Sam Muggleworth (PointSource, LLC)
  */
 
-// need to swap out a method, so swizzling it here
-static void swizzleMethod(Class class, SEL destinationSelector, SEL sourceSelector);
-
-@implementation AppDelegate (IdentityUrlHandling)
-
-+ (void)load {
-    swizzleMethod([AppDelegate class],
-                @selector(application:openURL:sourceApplication:annotation:),
-                @selector(identity_application:openURL:sourceApplication:annotation:));
-
-    swizzleMethod([AppDelegate class],
-                @selector(application:openURL:options:),
-                @selector(indentity_application_options:openURL:options:));
-}
-
-/** Google Sign-In SDK
- @date July 19, 2015
- */
-- (BOOL)identity_application: (UIApplication *)application
-                     openURL: (NSURL *)url
-           sourceApplication: (NSString *)sourceApplication
-                  annotation: (id)annotation {
-    GooglePlus* gp = (GooglePlus*) [self.viewController pluginObjects][@"GooglePlus"];
-
-    if ([gp isSigningIn]) {
-        gp.isSigningIn = NO;
-        return [[GIDSignIn sharedInstance] handleURL:url sourceApplication:sourceApplication annotation:annotation];
-    } else {
-        // call super
-        return [self identity_application:application openURL:url sourceApplication:sourceApplication annotation:annotation];
-    }
-}
-
-/**
-From https://github.com/EddyVerbruggen/cordova-plugin-googleplus/issues/227#issuecomment-227674026
-Fixes issue with G+ login window not closing correctly on ios 9
-*/
-- (BOOL)indentity_application_options: (UIApplication *)app
-            openURL: (NSURL *)url
-            options: (NSDictionary *)options
-{
-    GooglePlus* gp = (GooglePlus*) [self.viewController pluginObjects][@"GooglePlus"];
-
-    if ([gp isSigningIn]) {
-        gp.isSigningIn = NO;
-        return [[GIDSignIn sharedInstance] handleURL:url
-            sourceApplication:options[UIApplicationOpenURLOptionsSourceApplicationKey]
-            annotation:options[UIApplicationOpenURLOptionsAnnotationKey]];
-    } else {
-        // Other
-        return [self indentity_application_options:app openURL:url options:options];
-    }
-}
-@end
 
 @implementation GooglePlus
+
+}
+
+}
+
+{
+
+    }
+}
 
 // If this returns false, you better not call the login function because of likely app rejection by Apple,
 // see https://code.google.com/p/google-plus-platform/issues/detail?id=900
@@ -226,18 +181,4 @@ Fixes issue with G+ login window not closing correctly on ios 9
     [self.viewController dismissViewControllerAnimated:YES completion:nil];
 }
 
-#pragma mark Swizzling
-
 @end
-
-static void swizzleMethod(Class class, SEL destinationSelector, SEL sourceSelector) {
-  Method destinationMethod = class_getInstanceMethod(class, destinationSelector);
-  Method sourceMethod = class_getInstanceMethod(class, sourceSelector);
-
-  // If the method doesn't exist, add it.  If it does exist, replace it with the given implementation.
-  if (class_addMethod(class, destinationSelector, method_getImplementation(sourceMethod), method_getTypeEncoding(sourceMethod))) {
-    class_replaceMethod(class, destinationSelector, method_getImplementation(destinationMethod), method_getTypeEncoding(destinationMethod));
-  } else {
-    method_exchangeImplementations(destinationMethod, sourceMethod);
-  }
-}

--- a/src/ios/GooglePlus.m
+++ b/src/ios/GooglePlus.m
@@ -34,6 +34,17 @@
 - (void)handleOpenURLWithAppSourceAndAnnotation:(NSNotification*)notification
 {
 
+    NSMutableDictionary * options = [notification object];
+
+    NSURL* url = options[@"url"];
+
+    NSString* possibleReversedClientId = [url.absoluteString componentsSeparatedByString:@":"].firstObject;
+
+    if ([possibleReversedClientId isEqualToString:self.getreversedClientId] && self.isSigningIn) {
+        self.isSigningIn = NO;
+        [[GIDSignIn sharedInstance] handleURL:url
+                            sourceApplication:options[@"sourceApplication"]
+                            annotation:options[@"annotation"]];
     }
 }
 

--- a/src/ios/GooglePlus.m
+++ b/src/ios/GooglePlus.m
@@ -16,10 +16,22 @@
 
 @implementation GooglePlus
 
-}
+- (void)pluginInitialize
+{
+    NSLog(@"GooglePlus pluginInitizalize");
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleOpenURL:) name:CDVPluginHandleOpenURLNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleOpenURLWithAppSourceAndAnnotation:) name:CDVPluginHandleOpenURLWithAppSourceAndAnnotationNotification object:nil];
 
 }
 
+- (void)handleOpenURL:(NSNotification*)notification
+{
+
+    // no need to handle this handler, we dont have an sourceApplication here, which is required by GIDSignIn handleURL
+
+}
+
+- (void)handleOpenURLWithAppSourceAndAnnotation:(NSNotification*)notification
 {
 
     }


### PR DESCRIPTION
This fixes the issue where multiple URL types could not be handled. See issue https://github.com/EddyVerbruggen/cordova-plugin-googleplus/issues/506 This is because the application:openUrl method from  [CDVAppDelegate.m](https://github.com/apache/cordova-ios/blob/master/CordovaLib/Classes/Public/CDVAppDelegate.m) is swizzled. It starts an infinite loop. with the line [GooglePlus.m:66](https://github.com/EddyVerbruggen/cordova-plugin-googleplus/blob/ebe70066bee5f3a46fbd5335b13bf67074ea0585/src/ios/GooglePlus.m#L66).

Also because of the swizzling the original method is not called and therefore the notifications are not send. This causes that the observer in [CDVHandleOpenURL.m](https://github.com/apache/cordova-ios/blob/master/CordovaLib/Classes/Private/Plugins/CDVHandleOpenURL/CDVHandleOpenURL.m) is not triggered.

As of cordova-ios 4.5.0 the CDVPluginHandleOpenURLWithAppSourceAndAnnotationNotification is added, we can listen to this notification and ditch the swizzling. But this obviously breaks it for earlier verions of cordova-ios.

I hope this PR helps to create a more robust fix, where versions prior to cordova-ios@4.5.0 are handled properly as well.