### PR TITLE
Updating gms services versions to use + rather than specific version numbers

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -29,8 +29,8 @@
   <!-- android -->
   <platform name="android">
 
-    <framework src="com.google.android.gms:play-services-auth:11.8.0" />
-    <framework src="com.google.android.gms:play-services-identity:11.8.0" />
+    <framework src="com.google.android.gms:play-services-auth:16.0.0" />
+    <framework src="com.google.android.gms:play-services-identity:15.0.1" />
 
     <config-file target="res/xml/config.xml" parent="/*">
       <feature name="GooglePlus">

--- a/plugin.xml
+++ b/plugin.xml
@@ -29,8 +29,8 @@
   <!-- android -->
   <platform name="android">
 
-    <framework src="com.google.android.gms:play-services-auth:16.0.0" />
-    <framework src="com.google.android.gms:play-services-identity:15.0.1" />
+    <framework src="com.google.android.gms:play-services-auth:+" />
+    <framework src="com.google.android.gms:play-services-identity:+" />
 
     <config-file target="res/xml/config.xml" parent="/*">
       <feature name="GooglePlus">


### PR DESCRIPTION
I found that changing 11.8.0 to + for the com.google.android.gms:play-services-auth and com.google.android.gms:play-services-identity framework values gives a clean build and the plugin still works, i.e. you can login to google.