### PR TITLE
Added VSCode Cordova Simulate support

### DIFF
--- a/src/simulation/sim-host-handlers.js
+++ b/src/simulation/sim-host-handlers.js
@@ -1,0 +1,136 @@
+
+//import GooglePlusProxy from "../browser/GooglePlusProxy"
+
+module.exports = function(messages){
+
+	function _isAvailable(success, error){
+		if (!window.__googleSdkReady) {
+			return window.__googleCallbacks.push(function() {
+				_isAvailable(success, error);
+			});
+		}
+
+		success(window.gapi !== undefined);
+	}
+
+	function _updateSigninStatus (isSignedIn, success, error) {
+		if (isSignedIn) {
+			var auth2 = gapi.auth2.getAuthInstance();
+			var user = auth2.currentUser.get();
+			if (!user) {
+				error({'error': 'User not found.'});
+				return false;
+			}
+
+			var profile = user.getBasicProfile();
+			var authResponse = user.getAuthResponse(true);
+			if (success) {
+				success({
+					"accessToken": authResponse['access_token'],
+					"expires": authResponse['expires_at'],
+					"expires_in": authResponse['expires_in'],
+					"idToken": authResponse['id_token'],
+					"serverAuthCode": authResponse['server_auth_code'],
+					"email": profile.getEmail(),
+					"userId": profile.getId(),
+					"displayName": profile.getName(),
+					"familyName": profile.getFamilyName(),
+					"givenName": profile.getGivenName(),
+					"imageUrl": profile.getImageUrl()
+				});
+			}
+
+		} else {
+			if (error) error({'error': 'User not logged in.'});
+		}
+	}
+
+	function _trySilentLogin (success, error, options) {
+		if (!window.__googleSdkReady) {
+			return window.__googleCallbacks.push(function() {
+				_trySilentLogin(success, error, options);
+			});
+		}
+
+		_updateSigninStatus(gapi.auth2.getAuthInstance().isSignedIn.get(), success, error);
+	}
+
+	function _login (success, error, options) {
+		var that = this;
+		if (!window.__googleSdkReady) {
+			return window.__googleCallbacks.push(function() {
+				that.login(success, error, options);
+			});
+		}
+		
+		gapi.auth2.getAuthInstance().signIn(options).then(function () {
+			_updateSigninStatus(gapi.auth2.getAuthInstance().isSignedIn.get(), success, error);
+		}, function(err) {
+			error(err);
+		});
+	}
+
+	function _logout(success, error) {
+		const self = this
+		if (!window.__googleSdkReady) {
+			return window.__googleCallbacks.push(function() {
+				_.logout(success, error);
+			});
+		}
+
+		gapi.auth2.getAuthInstance().signOut().then(success, function(err) {
+			error(err);
+		});
+	}
+
+	function _disconnect(success, error) {
+		if (!window.__googleSdkReady) {
+			return window.__googleCallbacks.push(function() {
+				_disconnect(success, error);
+			});
+		}
+
+		gapi.auth2.getAuthInstance().disconnect().then(success, function(err) {
+			error(err);
+		});
+	}
+
+	function _getSigningCertificateFingerprint (success, error) {
+		console.warn('Not implemented.');
+		console.trace();
+	}
+
+
+	return {
+		GooglePlus: {
+			isAvailable: function(success, error){
+				_isAvailable(success, error);
+			},
+			updateSigninStatus: function (isSignedIn, success, error) {
+				_updateSigninStatus(isSignedIn, success, error)
+			},		
+			trySilentLogin: function (success, error, options) {
+				_trySilentLogin(success, error, options)
+			},
+		
+			login: function (success, error, options) {
+				_login(success, error, options)
+			},
+		
+			logout: function (success, error) {
+				_logout(success, error) 
+			},
+		
+			disconnect: function (success, error) {
+				_disconnect(success, error) 
+			},
+		
+			getSigningCertificateFingerprint: function (success, error) {
+				console.warn('Not implemented.');
+				console.trace();
+			}
+		}
+
+	}
+
+}

--- a/src/simulation/sim-host.js
+++ b/src/simulation/sim-host.js
@@ -1,0 +1,77 @@
+
+module.exports = {
+	initialize: function() {
+
+		//Not the best solution attaching to window, but instanced classes don't seem to work :/
+		window.__googleSdkReady = false;
+		window.__googleCallbacks = [];
+
+		if (window.location.protocol === "file:") {
+			console.warn("Google API is not supported when using file:// protocol");
+		} else {
+
+			//Extract WEB_APPLICATION_CLIENT_ID from config.xml
+			fetch("../config.xml")
+				.then(response => response.text())
+				.then(data => {
+					//We have the xml data.. Parse it
+					return this.getPreferenceValue(data, "WEB_APPLICATION_CLIENT_ID");
+				})
+				.then(clientId => {
+					if(clientId !== null){
+						this.initLoad(clientId);
+					} else {
+						console.error("Client id not found in config.xml")
+					}
+				})
+
+		};
+	},
+
+	getPreferenceValue: function(config, name) {
+		var value = config.match(new RegExp('name="' + name + '" value="(.*?)"', "i"));
+		if(value && value[1]) {
+			return value[1]
+		} else {
+			return null
+		}
+	},
+
+	initLoad: function(clientId){
+		const self = this
+
+		window.handleClientLoad = function() {
+			gapi.load('auth2', function () {
+				gapi.auth2.init({
+					client_id: clientId
+				}).then(function () {
+					window.__googleSdkReady = true;
+
+					for (var i = 0; i < window.__googleCallbacks.length; i++) {
+						window.__googleCallbacks[i].call(self);
+					}
+
+					// Listen for sign-in state changes.
+					gapi.auth2.getAuthInstance().isSignedIn.listen(self.updateSigninStatus);
+				}, function(error) {
+					if (error.details) {
+						console.error(error.details);
+					} else {
+						console.error(error);
+					}
+				});
+			});
+		};
+
+		(function(d, s, id){
+			var js, fjs = d.getElementsByTagName(s)[0];
+			if (d.getElementById(id)) {return;}
+			js = d.createElement(s); js.id = id;
+			js.onload = function () { window.handleClientLoad(); };
+			js.onreadystatechange = function () { if (this.readyState === 'complete') js.onload(); };
+			js.src = "https://apis.google.com/js/api.js";
+			fjs.parentNode.insertBefore(js, fjs);
+		}(document, 'script', 'googleplus-jssdk'));
+	}
+	
+}


### PR DESCRIPTION
Added VSCode "Cordova-simulate" support...

so you can now live-reload an emulated Android or IOS device in your browser with full working Google authentication, as the "cordova run browser" command doesn't support live/hot-reloading, and other things

https://code.visualstudio.com/
https://www.npmjs.com/package/cordova-simulate