### PR TITLE
fix #591

### DIFF
--- a/hooks/ios/install_entitlements.js
+++ b/hooks/ios/install_entitlements.js
@@ -7,7 +7,14 @@ var xcode = require('xcode'),
     util = require('util');
 
 module.exports = function (context) {
-  var Q = require('q');
+  var Q
+
+  try {
+    Q = require('q');
+  } catch (e) {
+    Q = context.requireCordovaModule('q');
+  }
+
   var deferral = new Q.defer();
 
   if (context.opts.cordova.platforms.indexOf('ios') < 0) {

--- a/hooks/ios/prerequisites.js
+++ b/hooks/ios/prerequisites.js
@@ -1,8 +1,17 @@
 console.error("Google Sign-In prerequisites");
 
 module.exports = function (context) {
-  var child_process = require('child_process'),
-      deferral = require('q').defer();
+  var child_process = require('child_process');
+
+  var Q
+
+  try {
+    Q = require('q');
+  } catch (e) {
+    Q = context.requireCordovaModule('q');
+  }
+
+  var deferral = Q.defer();
 
   var output = child_process.exec('npm install', {cwd: __dirname},
       function (error) {


### PR DESCRIPTION
Both `after_plugin_install` hooks now require the _q_ module by using this piece of code

```javascript
  var Q
  try {
    Q = require('q');
  } catch (e) {
    Q = context.requireCordovaModule('q');
  }
```
