### PR TITLE
Fix #617: CLIENT_ID not updated in after_prepare hook

### DIFF
--- a/hooks/browser/after_prepare.js
+++ b/hooks/browser/after_prepare.js
@@ -29,6 +29,6 @@ var files = [
 for(var i=0; i<files.length; i++) {
     try {
         var contents = fs.readFileSync(files[i]).toString();
-        fs.writeFileSync(files[i], contents.replace(/WEB_APPLICATION_CLIENT_ID/g, WEB_APPLICATION_CLIENT_ID));
+        fs.writeFileSync(files[i], contents.replace(/client_id: "[^"]+"/g, `client_id: "${WEB_APPLICATION_CLIENT_ID}"`));
     } catch(err) {}
 }


### PR DESCRIPTION
This is a fix for #617.

Basically, instead of always looking for `WEB_APPLICATION_CLIENT_ID` placeholder, we look at 
`client_id: "*"`.

Regards 🙂