### PR TITLE
fix: optimistic references for Cocoapods

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -96,8 +96,8 @@
         <source url="https://github.com/CocoaPods/Specs.git"/>
       </config>
       <pods use-frameworks="true">
-        <pod name="GoogleSignIn" spec="4.4.0"/>
-        <pod name="GoogleUtilities" spec="6.2.3"/>
+        <pod name="GoogleSignIn" spec="~> 4.4.0"/>
+        <pod name="GoogleUtilities" spec="~> 6.2.3"/>
       </pods>
     </podspec>
 


### PR DESCRIPTION
Hi Eddy,

I was facing the following error while installing an iOS platform after having removed it:

```
Inspecting targets to integrate
  Using `ARCHS` setting to build architectures of target `Pods-Circle`: (``)

Finding Podfile changes
  A GoogleSignIn
  A GoogleUtilities
  - Crashlytics
  - Fabric
  - Firebase

Resolving dependencies of `Podfile`

[!] CocoaPods could not find compatible versions for pod "GoogleUtilities/UserDefaults":
  In snapshot (Podfile.lock):
    GoogleUtilities/UserDefaults (= 6.2.5, ~> 6.0, ~> 6.2)

  In Podfile:
    GoogleUtilities (= 6.2.3) was resolved to 6.2.3, which depends on
      GoogleUtilities/UserDefaults (= 6.2.3)

None of your spec sources contain a spec satisfying the dependencies: `GoogleUtilities/UserDefaults (= 6.2.5, ~> 6.0, ~> 6.2), GoogleUtilities/UserDefaults (= 6.2.3)`.

You have either:
 * out-of-date source repos which you can update with `pod repo update` or with `pod install --repo-update`.
 * mistyped the name or version.
 * not added the source repo that hosts the Podspec to your Podfile.

Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by default.
```

It might be an incompatibility problem with another plugin which also use Cocoapods or the fact that I had to update my pod (`pod repo update`).

At first I was thinking to provide a PR where the POD reference would be made as a new variable, which would fits more users' use case, but unfortunately, Cordova not yet support this (there is an open issue in Cordova lib about it https://github.com/apache/cordova-lib/issues/789).

That's why I came with the suggestion of making the reference to the Cocoapods version a bit more open while specifying it as an optimistic reference (https://guides.cocoapods.org/using/the-podfile.html) which in the same time, solves my problem too.

Best regards
David
