### PR TITLE
Fix dependency list

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
     "android",
     "ios"
   ],
-  "dependencies": [
-    "q"
-  ],
+  "dependencies": {
+    "q": "*"
+  },
   "engines": [
     {
       "name": "cordova",


### PR DESCRIPTION
I don't know if this is a valid config for npm, but it's not for yarn. It ends up attempting to install the `0` package with version `q`.