### PR TITLE
Fix to make the plugin to work on browser platform with Cordova 9

### DIFF
--- a/hooks/browser/after_prepare.js
+++ b/hooks/browser/after_prepare.js
@@ -11,6 +11,14 @@ var getPreferenceValue = function(config, name) {
         return null
     }
 };
+var getPreferenceValueFromPackageJson = function (config, name) {
+    var value = config.match(new RegExp('"' + name + '":\\s"(.*?)"', "i"));
+    if (value && value[1]) {
+        return value[1]
+    } else {
+        return null
+    }
+};
 
 var WEB_APPLICATION_CLIENT_ID = '';
 
@@ -19,6 +27,10 @@ if(process.argv.join("|").indexOf("WEB_APPLICATION_CLIENT_ID=") > -1) {
 } else {
     var config = fs.readFileSync("config.xml").toString();
     WEB_APPLICATION_CLIENT_ID = getPreferenceValue(config, "WEB_APPLICATION_CLIENT_ID");
+    if (!WEB_APPLICATION_CLIENT_ID) {
+        var packageJson = fs.readFileSync("package.json").toString();
+        WEB_APPLICATION_CLIENT_ID = getPreferenceValueFromPackageJson(packageJson, "WEB_APPLICATION_CLIENT_ID");
+    }
 }
 
 var files = [


### PR DESCRIPTION
See https://github.com/EddyVerbruggen/cordova-plugin-googleplus/issues/666

The problem is that **after_prepare.js** hook for browser platform tries to read WEB_APPLICATION_CLIENT_ID value from config.xml however as of the latest Cordova 9 plugins and their preferences are saved into package.json (see https://github.com/apache/cordova-docs/issues/1004#issuecomment-510598007) so WEB_APPLICATION_CLIENT_ID value is not found and CLIENT_ID in GooglePlusProxy.js is not set as required.

The fix is, if WEB_APPLICATION_CLIENT_ID value is not found, try to read it from package.json and set if found.
 