### PR TITLE
Updating to CocoaPods CDN

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -104,11 +104,11 @@
     <!-- Google frameworks -->
     <podspec>
       <config>
-        <source url="https://github.com/CocoaPods/Specs.git"/>
+        <source url="https://cdn.cocoapods.org/"/>
       </config>
       <pods use-frameworks="true">
         <pod name="GoogleSignIn" spec="~> 5.0.2"/>
-        <pod name="GoogleUtilities" spec="~> 6.4.0"/>
+        <pod name="GoogleUtilities" spec="~> 6.5.1"/>
       </pods>
     </podspec>
 


### PR DESCRIPTION
Reasons:
1.) https://blog.cocoapods.org/CocoaPods-1.7.2/

2.) If you have multiple plugins, what already use CDN, you get "multiple specifications" error when this plugin install pods during `ionic cordova platform add ios`
```
[!] Found multiple specifications for GoogleUtilities (6.5.1):
-/Users/tetkosimi/.cocoapods/repos/cocoapods/Specs/0/8/4/GoogleUtilities/6.5.1/GoogleUtilities.podspec.json
-/Users/tetkosimi/.cocoapods/repos/trunk/Specs/0/8/4/GoogleUtilities/6.5.1/GoogleUtilities.podspec.json
...
[!] Found multiple specifications for Firebase (6.13.0):
[!] Found multiple specifications for FirebaseCoreDiagnostics (1.1.2):
[!] Found multiple specifications for GoogleUtilities (6.4.0):
[!] Found multiple specifications for AppAuth (1.1.0):
```
etc...

3.) GoogleUtilities 6.4.0 seems already deprecated.
```
[!] CocoaPods could not find compatible versions for pod "GoogleUtilities/UserDefaults”:
  In snapshot (Podfile.lock):
    GoogleUtilities/UserDefaults (= 6.5.1, ~> 6.0, ~> 6.2)

  In Podfile:
    GoogleUtilities (~> 6.4.0) was resolved to 6.4.0, which depends on
      GoogleUtilities/UserDefaults (= 6.4.0)

Specs satisfying the `GoogleUtilities/UserDefaults (= 6.5.1, ~> 6.0, ~> 6.2), GoogleUtilities/UserDefaults (= 6.4.0)` dependency were found, but they required a higher minimum deployment target.

```

Facebook plugin will be also updated soon.
https://github.com/jeduan/cordova-plugin-facebook4/pull/848