### PR TITLE
Update GoogleUtilities to version 7.2.2

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -108,7 +108,7 @@
       </config>
       <pods use-frameworks="true">
         <pod name="GoogleSignIn" spec="~> 5.0.2"/>
-        <pod name="GoogleUtilities" spec="~> 6.7"/>
+        <pod name="GoogleUtilities" spec="~> 7.2.2"/>
       </pods>
     </podspec>
 


### PR DESCRIPTION
Updating GoogleUtilities Pod to the lastest version fixes error "Failed to install 'cordova-plugin-googleplus': Error: pod: Command failed with exit code 1" when building for iOS on Xcode 12.3