### PR TITLE
chore: Update GoogleUtilities version

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -108,7 +108,7 @@
       </config>
       <pods use-frameworks="true">
         <pod name="GoogleSignIn" spec="~> 5.0.2"/>
-        <pod name="GoogleUtilities" spec="~> 6.7"/>
+        <pod name="GoogleUtilities" spec="~> 7.2.2"/>
       </pods>
     </podspec>
 


### PR DESCRIPTION
Update GoogleUtilities to 7.7.2 to avoid pod install failure.

The google utilities repo dropped old version which is making this plugin not work for iOS anymore https://github.com/google/GoogleUtilities/tags