### PR TITLE
Adding installation variable to use a custom GoogleUtilities pod version

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -52,7 +52,7 @@
 
   <!-- ios -->
   <platform name="ios">
-	<preference name="IOS_GOOGLEUTILITIES_VERSION" default="~> 6.32.2"/>
+	<preference name="IOS_GOOGLEUTILITIES_VERSION" default="~> 6.7"/>
 
     <config-file target="config.xml" parent="/*">
       <feature name="GooglePlus">

--- a/plugin.xml
+++ b/plugin.xml
@@ -52,6 +52,7 @@
 
   <!-- ios -->
   <platform name="ios">
+	<preference name="IOS_GOOGLEUTILITIES_VERSION" default="~> 6.32.2"/>
 
     <config-file target="config.xml" parent="/*">
       <feature name="GooglePlus">
@@ -108,7 +109,7 @@
       </config>
       <pods use-frameworks="true">
         <pod name="GoogleSignIn" spec="~> 5.0.2"/>
-        <pod name="GoogleUtilities" spec="~> 7.2.2"/>
+        <pod name="GoogleUtilities" spec="$IOS_GOOGLEUTILITIES_VERSION"/>
       </pods>
     </podspec>
 


### PR DESCRIPTION
The edit simply allow plugin users to define a custom GoogleUtilities pod version when installing plugin by adding the variable IOS_GOOGLEUTILITIES_VERSION to the installation command and assigning the desired version for it so that plugin users can solve installation issues raised by dependencies conflict with other plugins, specially cordova firebase plugins