### PR TITLE
chore: Update GoogleUtilities version

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -30,7 +30,7 @@
   <!-- android -->
   <platform name="android">
 
-	<preference name="PLAY_SERVICES_VERSION" default="15.0.1"/>
+    <preference name="PLAY_SERVICES_VERSION" default="15.0.1"/>
     <framework src="com.google.android.gms:play-services-auth:$PLAY_SERVICES_VERSION" />
     <framework src="com.google.android.gms:play-services-identity:$PLAY_SERVICES_VERSION" />
 
@@ -108,7 +108,7 @@
       </config>
       <pods use-frameworks="true">
         <pod name="GoogleSignIn" spec="~> 5.0.2"/>
-        <pod name="GoogleUtilities" spec="~> 7.2.2"/>
+        <pod name="GoogleUtilities" spec="~> 7.4"/>
       </pods>
     </podspec>
 


### PR DESCRIPTION
Update GoogleUtilities to 7.4 to avoid pod install failure.

The google utilities repo dropped old version which is making this plugin not work for iOS anymore https://github.com/google/GoogleUtilities/tags