### PR TITLE
Fixed a bug with signOut() not forgetting previous account

### DIFF
--- a/src/android/GooglePlus.java
+++ b/src/android/GooglePlus.java
@@ -101,7 +101,13 @@ public class GooglePlus extends CordovaPlugin implements GoogleApiClient.OnConne
 
         } else if (ACTION_LOGOUT.equals(action)) {
             Log.i(TAG, "Trying to logout!");
-            signOut();
+            new AsyncTask<String, String, String>() {
+                @Override
+                protected String doInBackground(String... params) {
+                    signOut();
+                    return null;
+                }
+            }.execute();
 
         } else if (ACTION_DISCONNECT.equals(action)) {
             Log.i(TAG, "Trying to disconnect the user");


### PR DESCRIPTION
This fixes #762 