### PR TITLE
feat(sdk): support latest SDK versions for Android and iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,20 @@ $ cordova plugin add https://github.com/EddyVerbruggen/cordova-plugin-googleplus
 $ cordova prepare
 ```
 
+EXTRA VARIABLES:
+
+If you need to install a specific version of `GoogleSignIn` library using pod you can pass it as a variable.
+This is optional, if this variable is not set the default version will be used.
+```
+--variable GOOGLE_SIGN_IN_VERSION="~> 6.2.3"
+```
+
+If you need to install a specific version of `GoogleUtilities` library using pod you can pass it as a variable.
+This is optional, if this variable is not set the default version will be used.
+```
+--variable GOOGLE_UTILITIES_VERSION="~> 7.4"
+```
+
 IMPORTANT:
 
 * _Please note that `myreversedclientid` is a place holder for the reversed clientId you find in your iOS configuration file. Do not surround this value with quotes. **(iOS only Applications)**_
@@ -183,12 +197,9 @@ document.addEventListener('deviceready', deviceReady, false);
 function deviceReady() {
     //I get called when everything's ready for the plugin to be called!
     console.log('Device is ready!');
-    window.plugins.googleplus.trySilentLogin(...);
+    window.plugins.googleplus.login(...);
 }
 ```
-
-### isAvailable
-3/31/16: This method is no longer required to be checked first. It is kept for code orthoganality.
 
 ### Login
 
@@ -237,31 +248,6 @@ Additional user information is available by use case. Add the scopes needed to t
 On Android, the error callback (third argument) receives an error status code if authentication was not successful. A description of those status codes can be found on Google's android developer website at [GoogleSignInStatusCodes](https://developers.google.com/android/reference/com/google/android/gms/auth/api/signin/GoogleSignInStatusCodes).
 
 On iOS, the error callback will include an [NSError localizedDescription](https://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Classes/NSError_Class/).
-
-### Try silent login
-You can call `trySilentLogin` to check if they're already signed in to the app and sign them in silently if they are.
-
-If it succeeds you will get the same object as the `login` function gets,
-but if it fails it will not show the authentication dialog to the user.
-
-Calling `trySilentLogin` is done the same as `login`, except for the function name.
-```javascript
-window.plugins.googleplus.trySilentLogin(
-    {
-      'scopes': '... ', // optional - space-separated list of scopes, If not included or empty, defaults to `profile` and `email`.
-      'webClientId': 'client id of the web app/server side', // optional - clientId of your Web application from Credentials settings of your project - On Android, this MUST be included to get an idToken. On iOS, it is not required.
-      'offline': true, // Optional, but requires the webClientId - if set to true the plugin will also return a serverAuthCode, which can be used to grant offline access to a non-Google server
-    },
-    function (obj) {
-      alert(JSON.stringify(obj)); // do something useful instead of alerting
-    },
-    function (msg) {
-      alert('error: ' + msg);
-    }
-);
-```
-
-It is strongly recommended that trySilentLogin is implemented with the same options as login, to avoid any potential complications.
 
 ### logout
 This will clear the OAuth2 token.

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
         id="cordova-plugin-googleplus"
-        version="8.5.2">
+        version="9.0.0">
 
   <name>Google SignIn</name>
 
@@ -30,9 +30,10 @@
   <!-- android -->
   <platform name="android">
 
-	<preference name="PLAY_SERVICES_VERSION" default="15.0.1"/>
-    <framework src="com.google.android.gms:play-services-auth:$PLAY_SERVICES_VERSION" />
-    <framework src="com.google.android.gms:play-services-identity:$PLAY_SERVICES_VERSION" />
+    <preference name="PLAY_SERVICES_AUTH_VERSION" default="20.3.0"/>
+    <preference name="PLAY_SERVICES_IDENTITY_VERSION" default="18.0.1"/>
+    <framework src="com.google.android.gms:play-services-auth:$PLAY_SERVICES_AUTH_VERSION" />
+    <framework src="com.google.android.gms:play-services-identity:$PLAY_SERVICES_IDENTITY_VERSION" />
 
     <config-file target="res/xml/config.xml" parent="/*">
       <feature name="GooglePlus">
@@ -102,17 +103,19 @@
     <framework src="libz.dylib" weak="true" />
 
     <!-- Google frameworks -->
+    <preference name="GOOGLE_SIGN_IN_VERSION" default="~> 6.2.3"/>
+    <preference name="GOOGLE_UTILITIES_VERSION" default="~> 7.4"/>
     <podspec>
       <config>
         <source url="https://cdn.cocoapods.org/"/>
       </config>
       <pods use-frameworks="true">
-        <pod name="GoogleSignIn" spec="~> 5.0.2"/>
-        <pod name="GoogleUtilities" spec="~> 7.2.2"/>
+        <pod name="GoogleSignIn" spec="$GOOGLE_SIGN_IN_VERSION"/>
+        <pod name="GoogleUtilities" spec="$GOOGLE_UTILITIES_VERSION"/>
       </pods>
     </podspec>
 
-		<hook type="after_plugin_install" src="hooks/ios/prerequisites.js"/>
+    <hook type="after_plugin_install" src="hooks/ios/prerequisites.js"/>
   </platform>
 
   <!-- browser -->

--- a/src/ios/GooglePlus.h
+++ b/src/ios/GooglePlus.h
@@ -1,16 +1,13 @@
 #import <Cordova/CDVPlugin.h>
 #import <GoogleSignIn/GoogleSignIn.h>
 
-@interface GooglePlus : CDVPlugin<GIDSignInDelegate, GIDSignInDelegate>
+@interface GooglePlus : CDVPlugin
 
 @property (nonatomic, copy) NSString* callbackId;
 @property (nonatomic, assign) BOOL isSigningIn;
 
-- (void) isAvailable:(CDVInvokedUrlCommand*)command;
 - (void) login:(CDVInvokedUrlCommand*)command;
-- (void) trySilentLogin:(CDVInvokedUrlCommand*)command;
 - (void) logout:(CDVInvokedUrlCommand*)command;
 - (void) disconnect:(CDVInvokedUrlCommand*)command;
-- (void) share_unused:(CDVInvokedUrlCommand*)command;
 
 @end

--- a/src/ios/GooglePlus.m
+++ b/src/ios/GooglePlus.m
@@ -26,164 +26,131 @@
 
     if ([possibleReversedClientId isEqualToString:self.getreversedClientId] && self.isSigningIn) {
         self.isSigningIn = NO;
-        [[GIDSignIn sharedInstance] handleURL:url];
+        [GIDSignIn.sharedInstance handleURL:url];
     }
 }
 
-// If this returns false, you better not call the login function because of likely app rejection by Apple,
-// see https://code.google.com/p/google-plus-platform/issues/detail?id=900
-// Update: should be fine since we use the GoogleSignIn framework instead of the GooglePlus framework
-- (void) isAvailable:(CDVInvokedUrlCommand*)command {
-  CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:YES];
-  [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
-}
 
 - (void) login:(CDVInvokedUrlCommand*)command {
-  [[self getGIDSignInObject:command] signIn];
-}
-
-/** Get Google Sign-In object
- @date July 19, 2015
- */
-- (void) trySilentLogin:(CDVInvokedUrlCommand*)command {
-    [[self getGIDSignInObject:command] restorePreviousSignIn];
-}
-
-/** Get Google Sign-In object
- @date July 19, 2015
- @date updated March 15, 2015 (@author PointSource,LLC)
- */
-- (GIDSignIn*) getGIDSignInObject:(CDVInvokedUrlCommand*)command {
     _callbackId = command.callbackId;
-    NSDictionary* options = command.arguments[0];
     NSString *reversedClientId = [self getreversedClientId];
 
     if (reversedClientId == nil) {
-        CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Could not find REVERSED_CLIENT_ID url scheme in app .plist"];
+        NSDictionary *errorDetails = @{@"status": @"error", @"message": @"Could not find REVERSED_CLIENT_ID url scheme in app .plist"};
+        CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:[self toJSONString:errorDetails]];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:_callbackId];
-        return nil;
+        return;
     }
 
     NSString *clientId = [self reverseUrlScheme:reversedClientId];
 
-    NSString* scopesString = options[@"scopes"];
-    NSString* serverClientId = options[@"webClientId"];
-    NSString *loginHint = options[@"loginHint"];
-    BOOL offline = [options[@"offline"] boolValue];
-    NSString* hostedDomain = options[@"hostedDomain"];
+    GIDConfiguration *config = [[GIDConfiguration alloc] initWithClientID:clientId];
 
+    GIDSignIn *signIn = GIDSignIn.sharedInstance;
 
-    GIDSignIn *signIn = [GIDSignIn sharedInstance];
-    signIn.clientID = clientId;
+    [signIn signInWithConfiguration:config presentingViewController:self.viewController callback:^(GIDGoogleUser * _Nullable user, NSError * _Nullable error) {
+        if (error) {
+            NSDictionary *errorDetails = @{@"status": @"error", @"message": error.localizedDescription};
+            CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:[self toJSONString:errorDetails]];
+            [self.commandDelegate sendPluginResult:pluginResult callbackId:self->_callbackId];
+        } else {
+            NSString *email = user.profile.email;
+            NSString *userId = user.userID;
+            NSURL *imageUrl = [user.profile imageURLWithDimension:120]; // TODO pass in img size as param, and try to sync with Android
+            NSDictionary *result = @{
+                           @"email"           : email,
+                           @"userId"          : userId,
+                           @"idToken"         : user.authentication.idToken,
+                           @"displayName"     : user.profile.name       ? : [NSNull null],
+                           @"givenName"       : user.profile.givenName  ? : [NSNull null],
+                           @"familyName"      : user.profile.familyName ? : [NSNull null],
+                           @"imageUrl"        : imageUrl ? imageUrl.absoluteString : [NSNull null],
+                           };
 
-    [signIn setLoginHint:loginHint];
-
-    if (serverClientId != nil && offline) {
-      signIn.serverClientID = serverClientId;
-    }
-
-    if (hostedDomain != nil) {
-        signIn.hostedDomain = hostedDomain;
-    }
-
-    signIn.presentingViewController = self.viewController;
-    signIn.delegate = self;
-
-    // default scopes are email and profile
-    if (scopesString != nil) {
-        NSArray* scopes = [scopesString componentsSeparatedByString:@" "];
-        [signIn setScopes:scopes];
-    }
-    return signIn;
+            CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString: [self toJSONString:result]];
+            [self.commandDelegate sendPluginResult:pluginResult callbackId:self->_callbackId];
+        }
+    }];
 }
 
+
 - (NSString*) reverseUrlScheme:(NSString*)scheme {
-  NSArray* originalArray = [scheme componentsSeparatedByString:@"."];
-  NSArray* reversedArray = [[originalArray reverseObjectEnumerator] allObjects];
-  NSString* reversedString = [reversedArray componentsJoinedByString:@"."];
-  return reversedString;
+    NSArray* originalArray = [scheme componentsSeparatedByString:@"."];
+    NSArray* reversedArray = [[originalArray reverseObjectEnumerator] allObjects];
+    NSString* reversedString = [reversedArray componentsJoinedByString:@"."];
+    return reversedString;
 }
 
 - (NSString*) getreversedClientId {
-  NSArray* URLTypes = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleURLTypes"];
+    NSArray* URLTypes = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleURLTypes"];
 
-  if (URLTypes != nil) {
-    for (NSDictionary* dict in URLTypes) {
-      NSString *urlName = dict[@"CFBundleURLName"];
-      if ([urlName isEqualToString:@"REVERSED_CLIENT_ID"]) {
-        NSArray* URLSchemes = dict[@"CFBundleURLSchemes"];
-        if (URLSchemes != nil) {
-          return URLSchemes[0];
+    if (URLTypes != nil) {
+        for (NSDictionary* dict in URLTypes) {
+            NSString *urlName = dict[@"CFBundleURLName"];
+            if ([urlName isEqualToString:@"REVERSED_CLIENT_ID"]) {
+                NSArray* URLSchemes = dict[@"CFBundleURLSchemes"];
+                if (URLSchemes != nil) {
+                    return URLSchemes[0];
+                }
+            }
         }
-      }
     }
-  }
-  return nil;
+    return nil;
 }
 
 - (void) logout:(CDVInvokedUrlCommand*)command {
-  [[GIDSignIn sharedInstance] signOut];
-  CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"logged out"];
-  [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+    [GIDSignIn.sharedInstance signOut];
+    NSDictionary *details = @{@"status": @"success", @"message": @"Logged out"};
+    CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:[self toJSONString:details]];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
 - (void) disconnect:(CDVInvokedUrlCommand*)command {
-  [[GIDSignIn sharedInstance] disconnect];
-  CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"disconnected"];
-  [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+    [GIDSignIn.sharedInstance disconnectWithCallback:^(NSError * _Nullable error) {
+        if(error == nil) {
+            NSDictionary *details = @{@"status": @"success", @"message": @"Disconnected"};
+            CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:[self toJSONString:details]];
+            [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+        } else {
+            NSDictionary *details = @{@"status": @"error", @"message": [error localizedDescription]};
+            CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:[self toJSONString:details]];
+            [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+        }
+    }];
 }
 
-- (void) share_unused:(CDVInvokedUrlCommand*)command {
-  // for a rainy day.. see for a (limited) example https://github.com/vleango/GooglePlus-PhoneGap-iOS/blob/master/src/ios/GPlus.m
+- (void) isSignedIn:(CDVInvokedUrlCommand*)command {
+    bool isSignedIn = [GIDSignIn.sharedInstance currentUser] != nil;
+    NSDictionary *details = @{@"status": @"success", @"message": (isSignedIn) ? @"true" : @"false"};
+    CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:[self toJSONString:details]];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
 #pragma mark - GIDSignInDelegate
-/** Google Sign-In SDK
- @date July 19, 2015
- */
 - (void)signIn:(GIDSignIn *)signIn didSignInForUser:(GIDGoogleUser *)user withError:(NSError *)error {
-    if (error) {
-        CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:error.localizedDescription];
-        [self.commandDelegate sendPluginResult:pluginResult callbackId:_callbackId];
-    } else {
-        NSString *email = user.profile.email;
-        NSString *idToken = user.authentication.idToken;
-        NSString *accessToken = user.authentication.accessToken;
-        NSString *refreshToken = user.authentication.refreshToken;
-        NSString *userId = user.userID;
-        NSString *serverAuthCode = user.serverAuthCode != nil ? user.serverAuthCode : @"";
-        NSURL *imageUrl = [user.profile imageURLWithDimension:120]; // TODO pass in img size as param, and try to sync with Android
-        NSDictionary *result = @{
-                       @"email"           : email,
-                       @"idToken"         : idToken,
-                       @"serverAuthCode"  : serverAuthCode,
-                       @"accessToken"     : accessToken,
-                       @"refreshToken"    : refreshToken,
-                       @"userId"          : userId,
-                       @"displayName"     : user.profile.name       ? : [NSNull null],
-                       @"givenName"       : user.profile.givenName  ? : [NSNull null],
-                       @"familyName"      : user.profile.familyName ? : [NSNull null],
-                       @"imageUrl"        : imageUrl ? imageUrl.absoluteString : [NSNull null],
-                       };
 
-        CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:result];
-        [self.commandDelegate sendPluginResult:pluginResult callbackId:_callbackId];
-    }
 }
 
-/** Google Sign-In SDK
- @date July 19, 2015
- */
 - (void)signIn:(GIDSignIn *)signIn presentViewController:(UIViewController *)viewController {
     self.isSigningIn = YES;
     [self.viewController presentViewController:viewController animated:YES completion:nil];
 }
 
-/** Google Sign-In SDK
- @date July 19, 2015
- */
 - (void)signIn:(GIDSignIn *)signIn dismissViewController:(UIViewController *)viewController {
     [self.viewController dismissViewControllerAnimated:YES completion:nil];
+}
+
+- (NSString*)toJSONString:(NSDictionary*)dictionaryOrArray {
+    NSError *error;
+         NSData *jsonData = [NSJSONSerialization dataWithJSONObject:dictionaryOrArray
+                                                       options:NSJSONWritingPrettyPrinted
+                                                         error:&error];
+         if (! jsonData) {
+            NSLog(@"%s: error: %@", __func__, error.localizedDescription);
+            return @"{}";
+         } else {
+            return [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+         }
 }
 
 @end


### PR DESCRIPTION
This PR updates SDKs for Android and iOS to the latest versions and provides override support as suggested by @marioshtika in the event that a non-conflicting / minor patch version can be targeted as needed. Several aspects of the iOS and Android code needed to be updated.

This unbreaks integration with other plugins such as [@havesource/cordova-plugin-push](https://github.com/havesource/cordova-plugin-push).

_NOTE: The current inception of this PR breaks support for `trySilentLogin` as it was not a required feature to support our app. I'm open to upstream contributions if it's something the community still needs, but it may be worth just shelving if the plugin is otherwise broken for the majority of users due to conflicting SDK dependencies across projects._